### PR TITLE
#39 Using '_' instead of '-' in role name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,52 +1,52 @@
-# mysql-role changelog
+# mysql_role changelog
 
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
-## [Unreleased](https://github.com/idealista-tech/mysql-role/tree/develop)
+## [Unreleased](https://github.com/idealista-tech/mysql_role/tree/develop)
 
-## [2.1.0](https://github.com/idealista-tech/mysql-role/tree/2.1.0) (04/04/2018)
-[Full Changelog](https://github.com/idealista/mysql-role/compare/2.1.0...2.0.0)
+## [2.1.0](https://github.com/idealista-tech/mysql_role/tree/2.1.0) (04/04/2018)
+[Full Changelog](https://github.com/idealista/mysql_role/compare/2.1.0...2.0.0)
 ### Added
-- [#35](https://github.com/idealista/mysql-role/issues/35) *Provide additional settings as option files included in playbook* @dortegau
+- [#35](https://github.com/idealista/mysql_role/issues/35) *Provide additional settings as option files included in playbook* @dortegau
 
 ### Fixed
-- [#34](https://github.com/idealista/mysql-role/issues/34) *Adding default value for mysql_datadir variable* @dortegau
+- [#34](https://github.com/idealista/mysql_role/issues/34) *Adding default value for mysql_datadir variable* @dortegau
 
-## [2.0.0](https://github.com/idealista-tech/mysql-role/tree/2.0.0) (22/03/2018)
-[Full Changelog](https://github.com/idealista/mysql-role/compare/2.0.0...1.3.0)
+## [2.0.0](https://github.com/idealista-tech/mysql_role/tree/2.0.0) (22/03/2018)
+[Full Changelog](https://github.com/idealista/mysql_role/compare/2.0.0...1.3.0)
 ### Changed
-- [#29](https://github.com/idealista/mysql-role/issues/29) *Options file could be modified adding or removing system variables without requiring a new release* @dortegau
+- [#29](https://github.com/idealista/mysql_role/issues/29) *Options file could be modified adding or removing system variables without requiring a new release* @dortegau
 
-## [1.3.0](https://github.com/idealista-tech/mysql-role/tree/1.3.0) (15/03/2018)
-[Full Changelog](https://github.com/idealista/mysql-role/compare/1.3.0...1.2.3)
+## [1.3.0](https://github.com/idealista-tech/mysql_role/tree/1.3.0) (15/03/2018)
+[Full Changelog](https://github.com/idealista/mysql_role/compare/1.3.0...1.2.3)
 ### Added
-- [#26](https://github.com/idealista/mysql-role/issues/26) *Adding the ability to configure SQL mode* @dortegau
+- [#26](https://github.com/idealista/mysql_role/issues/26) *Adding the ability to configure SQL mode* @dortegau
 
 ### Changed
-- [#25](https://github.com/idealista/mysql-role/issues/25) *Migrating to Molecule 2.10.1* @dortegau
+- [#25](https://github.com/idealista/mysql_role/issues/25) *Migrating to Molecule 2.10.1* @dortegau
 
 ### Fixed
-- [#24](https://github.com/idealista/mysql-role/issues/24) *Fixing my.cnf template (providing value to 'explicit_defaults_for_timestamp')* @dortegau
+- [#24](https://github.com/idealista/mysql_role/issues/24) *Fixing my.cnf template (providing value to 'explicit_defaults_for_timestamp')* @dortegau
 
-## [1.2.3](https://github.com/idealista-tech/mysql-role/tree/1.2.3) (09/03/2018)
-[Full Changelog](https://github.com/idealista/mysql-role/compare/1.2.3...1.2.0)
+## [1.2.3](https://github.com/idealista-tech/mysql_role/tree/1.2.3) (09/03/2018)
+[Full Changelog](https://github.com/idealista/mysql_role/compare/1.2.3...1.2.0)
 ### Fixed
-- [#21](https://github.com/idealista/mysql-role/issues/21)*Using my.cnf file provided as template instead of installation default file (mysql.cnf)* @dortegau
+- [#21](https://github.com/idealista/mysql_role/issues/21)*Using my.cnf file provided as template instead of installation default file (mysql.cnf)* @dortegau
 - *Fixing typo in config filename and changing invalid config values* @dortegau
 
-## [1.2.0](https://github.com/idealista-tech/mysql-role/tree/1.2.0) (10/08/2017)
-[Full Changelog](https://github.com/idealista/mysql-role/compare/1.2.0...1.1.0)
+## [1.2.0](https://github.com/idealista-tech/mysql_role/tree/1.2.0) (10/08/2017)
+[Full Changelog](https://github.com/idealista/mysql_role/compare/1.2.0...1.1.0)
 ### Added
 - *Integration with TravisCI and Ansible Galaxy* @jnogol
 - *Added variable in remounting task in tasks/service.yml* @jnogol
 
-## [1.1.0](https://github.com/idealista-tech/mysql-role/tree/1.1.0) (06/07/2017)
-[Full Changelog](https://github.com/idealista/mysql-role/compare/1.1.0...1.0.0)
+## [1.1.0](https://github.com/idealista-tech/mysql_role/tree/1.1.0) (06/07/2017)
+[Full Changelog](https://github.com/idealista/mysql_role/compare/1.1.0...1.0.0)
 ### Added
 - *Enabling support for Debian 9* @dortegau
 
-## [1.0.0](https://github.com/idealista-tech/mysql-role/tree/1.0.0) (13/03/2017)
+## [1.0.0](https://github.com/idealista-tech/mysql_role/tree/1.0.0) (13/03/2017)
 ### Fixed
 - *Certificate error downloading mysql* @jmonterrubio
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-![Logo](https://raw.githubusercontent.com/idealista/mysql-role/master/logo.gif)
+![Logo](https://raw.githubusercontent.com/idealista/mysql_role/master/logo.gif)
 
 # MySQL Ansible role
-[![Build Status](https://travis-ci.org/idealista/mysql-role.png)](https://travis-ci.org/idealista/mysql-role)
+
+[![Build Status](https://travis-ci.org/idealista/mysql_role.png)](https://travis-ci.org/idealista/mysql_role)
+[![Ansible Galaxy](https://img.shields.io/badge/galaxy-idealista.mysql__role-B62682.svg)](https://galaxy.ansible.com/idealista/mysql_role)
 
 This ansible role installs a Prometheus Node Exporter in a debian environment.
 
@@ -32,7 +34,7 @@ For testing purposes, [Molecule](https://molecule.readthedocs.io/) with Docker a
 Create or add to your roles dependency file (e.g requirements.yml):
 
 ```
-- src: idealista.mysql-role
+- src: idealista.mysql_role
   version: 1.0.0
   name: mysql
 ```
@@ -118,7 +120,7 @@ mysql> show databases;
 
 ## Versioning
 
-For the versions available, see the [tags on this repository](https://github.com/idealista/mysql-role/tags).
+For the versions available, see the [tags on this repository](https://github.com/idealista/mysql_role/tags).
 
 Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGELOG.md) file.
 
@@ -126,7 +128,7 @@ Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGE
 
 * **Idealista** - *Work with* - [idealista](https://github.com/idealista)
 
-See also the list of [contributors](https://github.com/idealista/mysql-role/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/idealista/mysql_role/contributors) who participated in this project.
 
 ## License
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 
 galaxy_info:
+  role_name: mysql_role
   company: Idealista S.A.U
   description: MySQL role
   min_ansible_version: 2.4.3.0

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: mysql-role
+    - role: mysql_role


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

Coherence with role name requirements imposed by Ansible Galaxy (Both GitHub repo and Galaxy artifact has the same 'id').

### Possible Drawbacks

I don't know 😇

### Applicable Issues

#23