### PR TITLE
Fixed users default privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 - [#41](https://github.com/idealista/mysql_role/pull/41) *Manage replicate_ignore_table special case* @vide
 
+### Fixed 
+- [#43](https://github.com/idealista/mysql_role/pull/43) *Fixed users default privileges* @vide
+
 ## [2.1.0](https://github.com/idealista-tech/mysql_role/tree/2.1.0) (04/04/2018)
 [Full Changelog](https://github.com/idealista/mysql_role/compare/2.1.0...2.0.0)
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ mysql_users: []
 #   - name: example
 #     host: 127.0.0.1
 #     password: secret
-#     priv: [ *.*:USAGE ]
+#     priv: [ '*.*:USAGE' ]
 
 # Remounting settings
 mysql_remount_run: true

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -15,7 +15,7 @@
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
     password: "{{ item.password }}"
-    priv: "{{  item.priv | default('*.*:USAGE') | join('/') }}"
+    priv: "{{  item.priv | default(['*.*:USAGE']) | join('/') }}"
     append_privs: "yes"
   with_items: "{{ mysql_users }}"
   no_log: true


### PR DESCRIPTION
### Description of the Change

The code expects `mysql_users.priv` to be a list, but both the default value and the example in `default.yml` were wrong. The first was setting a string, not a list, and the latter did not quote the string in the flow collection

## Benefits

User creation without explicitly setting the `priv` value now works out of the box. The example is now working too.