### PR TITLE
bugs/57 Fix service error adding daemon reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/mysql_role/tree/develop)
+### Fixed
+- [#57](https://github.com/idealista/mysql_role/issues/57) *Fix debian 10 issue ensuring service is started on boot* @pablogcaldito
 
 ## [3.0.0](https://github.com/idealista/mysql_role/tree/3.0.0) (17/07/2019)
 [Full Changelog](https://github.com/idealista/mysql_role/compare/2.2.1...3.0.0)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -89,6 +89,7 @@
     name: mysql
     state: started
     enabled: true
+    daemon_reload: true
 
 - name: MySQL | Flush handlers to restart MySQL after previous initialization
   meta: flush_handlers


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Add daemon reload in system task to prevent it failing in Debian 10 hosts
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

The role no longer fails in Debian 10 hosts

### Possible Drawbacks

None

### Applicable Issues

#57 
