### PR TITLE
#82 select the major release version of mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
+## Unreleased
+### Added
+- [#82](https://github.com/idealista/mysql_role/issues/82) *Provide options to install non-default mysql versions* @blalop
+
 ## [4.3.0](https://github.com/idealista/mysql_role/tree/4.3.0)
 [Full Changelog](https://github.com/idealista/mysql_role/compare/4.2.0...4.3.0)
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ mysql_users:
      priv: [ example_DB.*:ALL ]
 ```
 
+### Selecting a major release version
+
+Major releases of MySQL can be selected using `mysql_server_version`. You can see the available options in the MySQL Debian mirror.
+
 ## Testing
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ mysql_flavour: mysql
 mysql_version: 0.8.19-1
 
 # If looking for an specific mysql version:
-mysql_server_version: mysql-5.7
+# mysql_server_version: mysql-5.7
 
 mysql_oracle_gpg_keyserver: keyserver.ubuntu.com
 mysql_oracle_gpg_key: 467B942D3A79BD29

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ mysql_flavour: mysql
 mysql_version: 0.8.19-1
 
 # If looking for an specific mysql version:
-# mysql_server_version: mysql-5.7
+mysql_server_version: mysql-5.7
 
 mysql_oracle_gpg_keyserver: keyserver.ubuntu.com
 mysql_oracle_gpg_key: 467B942D3A79BD29
@@ -39,7 +39,7 @@ mysql_service_state: started
 mysql_config_file: /etc/mysql/my.cnf
 mysql_pid_file: /var/run/mysqld/mysqld.pid
 mysql_datadir: /var/lib/mysql
-mysql_share_dir: /usr/share/mysql-8.0 # /usr/share/mysql for mysql 5
+mysql_share_dir: /usr/share/mysql  # /usr/share/mysql for mysql 5
 
 # Allowing playbooks to provide external option files
 mysql_extra_conf_include_dir: /etc/mysql/conf.d

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ mysql_service_state: started
 mysql_config_file: /etc/mysql/my.cnf
 mysql_pid_file: /var/run/mysqld/mysqld.pid
 mysql_datadir: /var/lib/mysql
-mysql_share_dir: /usr/share/mysql  # /usr/share/mysql for mysql 5
+mysql_share_dir: /usr/share/mysql-8.0  # /usr/share/mysql for mysql 5
 
 # Allowing playbooks to provide external option files
 mysql_extra_conf_include_dir: /etc/mysql/conf.d

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ mysql_flavour: mysql
 
 mysql_version: 0.8.19-1
 
+# If looking for an specific mysql version:
+# mysql_server_version: mysql-5.7
+
 mysql_oracle_gpg_keyserver: keyserver.ubuntu.com
 mysql_oracle_gpg_key: 467B942D3A79BD29
 
@@ -36,7 +39,7 @@ mysql_service_state: started
 mysql_config_file: /etc/mysql/my.cnf
 mysql_pid_file: /var/run/mysqld/mysqld.pid
 mysql_datadir: /var/lib/mysql
-mysql_share_dir: /usr/share/mysql-8.0
+mysql_share_dir: /usr/share/mysql-8.0 # /usr/share/mysql for mysql 5
 
 # Allowing playbooks to provide external option files
 mysql_extra_conf_include_dir: /etc/mysql/conf.d

--- a/tasks/install_mysql.yml
+++ b/tasks/install_mysql.yml
@@ -18,6 +18,14 @@
     pkg: "{{ mysql_required_libs }}"
     state: present
 
+- name: MySQL | Set MySQL server version
+  debconf:
+    name: mysql-apt-config
+    question: mysql-apt-config/select-server
+    vtype: select
+    value: "{{ mysql_server_version }}"
+  when: mysql_server_version is defined
+
 - name: MySQL | Download MySQL config deb
   get_url:
     url: "{{ mysql_deb_repo }}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

Add a step setting `mysql-apt-config/select-server` debconf when provided, so major release versions can be selected.


### Benefits

Gives the option to install a non-default mysql version.

### Possible Drawbacks

None, as it is an optional step.

### Applicable Issues

#82 
